### PR TITLE
Fix menu dotted lines to text ending

### DIFF
--- a/src/components/dish/dish.svelte
+++ b/src/components/dish/dish.svelte
@@ -1,17 +1,20 @@
 <script>
+  import { formatDescription } from '../../utils/format';
   export let dish
+ 
 </script>
 <div class="dish">
   <h4>{dish.nombre}</h4>
   <div class="details">
     <div class="description">
-      <p>{dish.descripcion||""}</p>
+      <p><span>{formatDescription(dish)||""}</span></p>
     </div>
-    <div class="fill"></div>
+    <div class="spacer"/>
     <div class="price">
-      <p>${dish.precio}</p>
+      <p><span>${dish.precio}</span></p>
     </div>
   </div>
+  <div class="fill"></div>
 </div><!-- dish end -->
 
 <style>
@@ -24,7 +27,12 @@
     font-weight: 400;
     margin: 0;
   }
-
+  .spacer{
+    min-width: 20px;
+  }
+  span {
+    background-color:#000;    
+  }
   .dish p {
     margin: 0;
     font-weight: 300;
@@ -44,20 +52,22 @@
     font-weight: 600;
   }
 
-  .dish .details .fill {
+  .fill {
+    z-index:-1;
     border-bottom: 1px dotted;
     flex: 1;
     min-width: 20px;
+    margin-top: -.4em;
   }
   @media(min-width:1200px){
-    .dish .details .fill {
+    .fill {
       border-bottom: 2px dotted;
       flex: 1;
       min-width: 20px;
     }
   }
   @media(min-width:1500px){
-    .dish .details .fill {
+    .fill {
       border-bottom: 3px dotted;
       flex: 1;
       min-width: 20px;

--- a/src/components/dish/dish.svelte
+++ b/src/components/dish/dish.svelte
@@ -31,7 +31,8 @@
     min-width: 20px;
   }
   span {
-    background-color:#000;    
+    background-color:#000;
+    padding: 0 3px;  
   }
   .dish p {
     margin: 0;

--- a/src/components/dish/index.svelte
+++ b/src/components/dish/index.svelte
@@ -44,6 +44,7 @@
   }
   span {
     background-color:#fff3e2;    
+    padding: 0 3px;  
   }
   .dish .details .price p {
     font-size: 1em;

--- a/src/components/dish/index.svelte
+++ b/src/components/dish/index.svelte
@@ -1,17 +1,19 @@
 <script>
+  import { formatDescription } from '../../utils/format';
   export let dish
 </script>
 <div class="dish">
   <h4>{dish.nombre}</h4>
   <div class="details">
     <div class="description">
-      <p>{dish.descripcion||""}</p>
+      <p><span>{formatDescription(dish)||""}</span></p>
     </div>
-    <div class="fill"></div>
+    <div class="spacer"/>
     <div class="price">
-      <p>${dish.precio}</p>
+      <p><span>${dish.precio}</span></p>
     </div>
   </div>
+  <div class="fill"></div>
 </div><!-- dish end -->
 
 <style>
@@ -24,7 +26,9 @@
     font-weight: 400;
     margin: 0;
   }
-
+  .spacer{
+    min-width: 20px;
+  }
   .dish p {
     margin: 0;
     font-weight: 300;
@@ -38,29 +42,30 @@
   .dish .details .description {
     font-size: 1em;
   }
-
+  span {
+    background-color:#fff3e2;    
+  }
   .dish .details .price p {
     font-size: 1em;
     font-weight: 600;
+    background-color:#fff3e2;
   }
 
-  .dish .details .fill {
+  .fill {
+    z-index:-1;
     border-bottom: 1px dotted;
     flex: 1;
     min-width: 20px;
+    margin-top: -.4em;
   }
    @media(min-width:1200px){
-    .dish .details .fill {
+    .fill {
       border-bottom: 2px dotted;
-      flex: 1;
-      min-width: 20px;
     }
   }
   @media(min-width:1500px){
-    .dish .details .fill {
+    .fill {
       border-bottom: 3px dotted;
-      flex: 1;
-      min-width: 20px;
     }
   }
 </style>

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,0 +1,8 @@
+function formatDescription({descripcion}){
+  let lastChar = descripcion.slice(-1);
+  return lastChar == '.'? descripcion.slice(0,-1):descripcion;
+}
+
+export {
+  formatDescription
+}


### PR DESCRIPTION
#### What does this PR do?
Fix the dotted lines to end of text instead of end of container.
Add an utility function to remove the final dot on dish description.

#### where should the reviewer start from?
* `src/components/dish` 
* `src/utils/format` 

#### Any background context you want to provide?
Base branch is `feat/connect_dark_menu` as it handles those existing styles.