### PR TITLE
show menu if restaurant has only one

### DIFF
--- a/src/routes/[restaurantslug]/[menuslug].svelte
+++ b/src/routes/[restaurantslug]/[menuslug].svelte
@@ -1,25 +1,8 @@
 <script context="module">
-  import { getMenuSingle, getPlatillosByCategoria, uploadsUrl } from "../../utils/api.js"
+  import { uploadsUrl,fetchData } from "../../utils/api.js"
   export async function preload({ params }) {
-    let { restaurantslug, menuslug } = params;
-    //pide el menu actual y los platillos con las categorias que vienen en el menu
-    const [menu] = await getMenuSingle(menuslug)
-    const platillos = await getPlatillosByCategoria(menu.categorias)
-    const categoriesArray = menu.categorias.sort((a, b) => {
-      return a.Orden - b.Orden
-    })
-    //crea un objecto de categorias y le agrega los platillos que le corresponden
-    const categories = categoriesArray.reduce((result, cat) => {
-      result[cat.id] = { ...cat, dishes: [] }
-      return result
-    }, {})
-    for (let dish of platillos) {
-      const { categorias, ...newDish } = dish
-      for(let categoria of categorias){
-        categories[categoria.id].dishes.push(newDish)
-      }
-    }
-    return { menu, categories, platillos, uploadsUrl };
+    let { menuslug } = params;
+    return await fetchData(menuslug)
   }
 </script>
 <script>

--- a/src/routes/[restaurantslug]/index.svelte
+++ b/src/routes/[restaurantslug]/index.svelte
@@ -1,0 +1,71 @@
+<script context="module">
+  import SingleMenu from './[menuslug].svelte';
+  import { fetchData,getMenuByRestaurant, uploadsUrl } from "../../utils/api.js"
+  export async function preload({ params }) {
+    let { restaurantslug } = params;
+    const menus = await getMenuByRestaurant(restaurantslug)
+    // check if list of menus
+    if(menus.length == 0){
+      return { error: true }
+    }
+    // check if render a list
+    if (menus.length>1){
+      return { menus, single:false }
+    }
+    // fetch a menu
+    const { slug } = menus[0]
+    const menuData = await fetchData(slug)
+    return {...menuData, single:true}
+  }
+</script>
+
+<script>
+  export let error
+  export let menus
+  export let single
+  $: navMenus = (menus||[]).map(menu => ({
+    link: `/${menu.restaurante.slug}/${menu.slug}`,
+  title: menu.nombre
+  }))
+  import Brown4Images from "../../components/brown4images.svelte"
+  import DarkTemplate from "../../components/darktemplate.svelte"
+  import WhiteTemplate from "../../components/whitetemplate.svelte"
+
+  export let menu;
+  export let categories
+  export let uploadsUrl
+  export let template
+  function getImageUrl(image) {
+    return `${uploadsUrl}${image.url}`
+  }
+</script>
+{#if !error}
+  {#if !single}
+  <nav>
+    {#each navMenus as menu}
+      <a href={menu.link}>{menu.title}</a>
+    {/each}
+  </nav>
+  {:else}
+    {#if template === 1}
+      <Brown4Images getImageUrl={getImageUrl} menu={menu} categories={categories} />
+    {:else if template === 2}
+      <DarkTemplate getImageUrl={getImageUrl} menu={menu} categories={categories} />
+    {:else}
+      <WhiteTemplate getImageUrl={getImageUrl} menu={menu} categories={categories} />
+    {/if}
+  {/if}
+{:else}
+  <h1> 404 El restaurante no tiene un menú activo o no está registrado en la plataforma.</h1>
+{/if}
+
+<style>
+  /* nav {
+    visibility: hidden;
+    opacity: 0;
+    display: none;
+  } */
+  nav a{
+    display: block;
+  }
+</style>

--- a/src/routes/allmenus.svelte
+++ b/src/routes/allmenus.svelte
@@ -1,7 +1,7 @@
 <script context="module">
-  import { getMenus } from "../utils/api.js"
+  import { getRestaurants } from "../utils/api.js"
   export async function preload() {
-    const menus = await getMenus()
+    const menus = await getRestaurants()
     return { menus }
   }
 </script>
@@ -10,8 +10,8 @@
   export let menus
   // console.log('menus', menus)
   $: navMenus = menus.map(menu => ({
-    link: `/${menu.restaurante.slug}/${menu.slug}`,
-    title: menu.nombre
+    link: `/${menu.slug}`,
+    title: menu.slug
   }))
 </script>
 


### PR DESCRIPTION
#### What does this PR do?
* Menu fetching moved to api
* Changed all menus for listing restaurants
* Error handling when no restaurant or not single menu
* Error handling when fetching empty array
#### Where should the reviewer start from?
* `restaurantslug/index.svelte`
* `utils/api`

#### How should this be tested?
* Enter `localhost:3000/allmenus` you'll see the list of restaurants the url is rewrited as `/restaurantSlug` 
* Pick Rooster: Rooster has 2 menus; so it will show a list of their menus 
  * Pick any of their menus -> `/rooster/alimentos`
* Pick Differenza: Differenza has only one menu; so it will show that available menu -> `/differenza`
#### Errror handling?
* Of course, enter to: `localhost:3000/AnyNiceRestaurantNameYouCanThink` need css; but was only for testing purpose
* Probably we should restructure the urls to `restaurantalia.com/restaurant/:restaurantSlug` for missleading 404 messages
#### Any background context you want to provide?
Base branch is `feat/strapi_connect`