### PR TITLE
Fix firefox view

### DIFF
--- a/src/components/brown4images.svelte
+++ b/src/components/brown4images.svelte
@@ -171,10 +171,4 @@
     }
   }
 
-  @media (min-width: 1400px) {
-    .menu-content {
-      grid-column-gap: 200px;
-      /* column-gap: 200px; */
-    }
-  }
 </style>

--- a/src/components/darktemplate.svelte
+++ b/src/components/darktemplate.svelte
@@ -124,7 +124,6 @@
 
     .menu.dark-menu .menu-content {
       column-count: 3;
-      column-gap: 60px;
     }
     .column {
       min-width: 30%;
@@ -133,9 +132,4 @@
     }
   }
 
-  @media (min-width: 1400px) {
-    .menu-content {
-      grid-column-gap: 200px;
-    }
-  }
 </style>

--- a/src/components/dish/dish.svelte
+++ b/src/components/dish/dish.svelte
@@ -1,22 +1,39 @@
 <script>
-  import { formatDescription } from '../../utils/format';
-  export let dish
+  import { formatDescription } from "../../utils/format";
+  export let dish;
 </script>
-<div class="dish">
-  <h4>{dish.nombre}</h4>
-  <div class="details">
-    <div class="description">
-      <p><span>{formatDescription(dish)||""}</span></p>
-    </div>
-    <div class="spacer"/>
-    <div class="price">
-      <p><span>${dish.precio}</span></p>
-    </div>
-  </div>
-  <div class="fill"></div>
-</div><!-- dish end -->
 
 <style>
+  ul.details {
+    max-width: 40em;
+    padding: 0;
+    overflow-x: hidden;
+    list-style: none;
+    font-size: 1em;
+  }
+  ul.details li:after {
+    float: left;
+    width: 0;
+    white-space: nowrap;
+    color: #fff;
+    content: ". . . . . . . . . . . . . . . . . . . . "
+      ". . . . . . . . . . . . . . . . . . . . "
+      ". . . . . . . . . . . . . . . . . . . . "
+      ". . . . . . . . . . . . . . . . . . . . ";
+  }
+  ul.details span:first-child {
+    padding-right: 0.33em;
+    background: #000;
+  }
+  ul.details span + span {
+    float: right;
+    padding-left: 0.33em;
+    font-size: 1em;
+    font-weight: 600;
+    background: #000;
+    position: relative;
+    z-index: 1;
+  }
   .dish {
     padding: 5px 20px;
   }
@@ -26,51 +43,15 @@
     font-weight: 400;
     margin: 0;
   }
-  .spacer{
-    min-width: 20px;
-  }
-  span {
-    background-color:#000;
-    padding: 0 3px;  
-  }
-  .dish p {
-    margin: 0;
-    font-weight: 300;
-  }
-
-  .dish .details {
-    display: flex;
-    align-items: flex-end;
-  }
-
-  .dish .details .description {
-    font-size: 1em;
-  }
-
-  .dish .details .price p {
-    font-size: 1em;
-    font-weight: 600;
-  }
-
-  .fill {
-    z-index:-1;
-    border-bottom: 1px dotted;
-    flex: 1;
-    min-width: 20px;
-    margin-top: -.4em;
-  }
-  @media(min-width:1200px){
-    .fill {
-      border-bottom: 2px dotted;
-      flex: 1;
-      min-width: 20px;
-    }
-  }
-  @media(min-width:1500px){
-    .fill {
-      border-bottom: 3px dotted;
-      flex: 1;
-      min-width: 20px;
-    }
-  }
 </style>
+
+<div class="dish">
+  <h4>{dish.nombre}</h4>
+  <ul class="details">
+    <li>
+      <span>{formatDescription(dish) || ''}</span>
+      <span>${dish.precio}</span>
+    </li>
+  </ul>
+</div>
+<!-- dish end -->

--- a/src/components/dish/index.svelte
+++ b/src/components/dish/index.svelte
@@ -1,22 +1,38 @@
 <script>
-  import { formatDescription } from '../../utils/format';
-  export let dish
+  import { formatDescription } from "../../utils/format";
+  export let dish;
 </script>
-<div class="dish">
-  <h4>{dish.nombre}</h4>
-  <div class="details">
-    <div class="description">
-      <p><span>{formatDescription(dish)||""}</span></p>
-    </div>
-    <div class="spacer"/>
-    <div class="price">
-      <p><span>${dish.precio}</span></p>
-    </div>
-  </div>
-  <div class="fill"></div>
-</div><!-- dish end -->
 
 <style>
+  ul.details {
+    max-width: 40em;
+    padding: 0;
+    overflow-x: hidden;
+    list-style: none;
+    font-size: 1em;
+  }
+  ul.details li:after {
+    float: left;
+    width: 0;
+    white-space: nowrap;
+    content: ". . . . . . . . . . . . . . . . . . . . "
+      ". . . . . . . . . . . . . . . . . . . . "
+      ". . . . . . . . . . . . . . . . . . . . "
+      ". . . . . . . . . . . . . . . . . . . . ";
+  }
+  ul.details span:first-child {
+    padding-right: 0.33em;
+    background: #fff3e2;
+  }
+  ul.details span + span {
+    float: right;
+    padding-left: 0.33em;
+    font-size: 1em;
+    font-weight: 600;
+    background: #fff3e2;
+    position: relative;
+    z-index: 1;
+  }
   .dish {
     padding: 5px 20px;
   }
@@ -26,47 +42,19 @@
     font-weight: 400;
     margin: 0;
   }
-  .spacer{
-    min-width: 20px;
-  }
-  .dish p {
-    margin: 0;
-    font-weight: 300;
-  }
-
-  .dish .details {
-    display: flex;
-    align-items: flex-end;
-  }
-
-  .dish .details .description {
-    font-size: 1em;
-  }
   span {
-    background-color:#fff3e2;    
-    padding: 0 3px;  
-  }
-  .dish .details .price p {
-    font-size: 1em;
-    font-weight: 600;
-    background-color:#fff3e2;
-  }
-
-  .fill {
-    z-index:-1;
-    border-bottom: 1px dotted;
-    flex: 1;
-    min-width: 20px;
-    margin-top: -.4em;
-  }
-   @media(min-width:1200px){
-    .fill {
-      border-bottom: 2px dotted;
-    }
-  }
-  @media(min-width:1500px){
-    .fill {
-      border-bottom: 3px dotted;
-    }
+    background-color: #fff3e2;
+    padding: 0 3px;
   }
 </style>
+
+<div class="dish">
+  <h4>{dish.nombre}</h4>
+  <ul class="details">
+    <li>
+      <span>{formatDescription(dish) || ''}</span>
+      <span>${dish.precio}</span>
+    </li>
+  </ul>
+</div>
+<!-- dish end -->

--- a/src/components/dish/whitedish.svelte
+++ b/src/components/dish/whitedish.svelte
@@ -1,71 +1,68 @@
 <script>
-  export let dish
+  import { formatDescription } from "../../utils/format";
+  export let dish;
+  export let column;
 </script>
-<div class="dish">
-  <h4>
-    <li>
-    {dish.nombre}
-    </li>
-  </h4>
-  <div class="details">
-    <div class="description">
-      <p>{dish.descripcion||""}</p>
-    </div>
-    <div class="fill"></div>
-    <div class="price">
-      <p>${dish.precio}</p>
-    </div>
-  </div>
-</div><!-- dish end -->
 
 <style>
+  ul.details {
+    max-width: 40em;
+    padding: 0;
+    padding-left: 5%;
+    overflow-x: hidden;
+    list-style: none;
+    font-size: 1em;
+  }
+  ul.details li:after {
+    float: left;
+    width: 0;
+    white-space: nowrap;
+    content: ". . . . . . . . . . . . . . . . . . . . "
+      ". . . . . . . . . . . . . . . . . . . . "
+      ". . . . . . . . . . . . . . . . . . . . "
+      ". . . . . . . . . . . . . . . . . . . . ";
+  }
+  ul.details span:first-child {
+    padding-right: 0.33em;
+    background: #f0efed;
+  }
+  ul.details span + span {
+    float: right;
+    padding-left: 0.33em;
+    font-size: 1em;
+    font-weight: 600;
+    background: #f0efed;
+    position: relative;
+    z-index: 1;
+  }
+
   .dish {
     padding: 5px 20px;
   }
-
+  .leftDishPad {
+    padding-left: 3%;
+    padding-right: 25%;
+  }
+  .rightDishPad {
+    padding-right: 15%;
+    padding-left: 10%;
+  }
   .dish h4 {
     font-size: 1em;
     font-weight: 400;
     margin: 0;
   }
-
-  .dish p {
-    margin: 0;
-    font-weight: 300;
-  }
-
-  .dish .details {
-    display: flex;
-    align-items: flex-end;
-
-  }
-
-  .dish .details .description {
-    font-size: 1em;
-  }
-
-  .dish .details .price p {
-    font-size: 1em;
-    font-weight: 600;
-  }
-
-  .dish .details .fill {
-    border-bottom: 1px dotted;
-    flex: 1;
-    min-width: 20px;
-  }
-  @media(min-width:1200px){
-    .dish .details .fill {
-      border-bottom: 2px dotted;
-      flex: 1;
-      min-width: 20px;
-    }
-  }
-  @media(min-width:1500px){
-    .dish .details .fill {
-      border-bottom: 3px dotted;
-      flex: 1;
-      min-width: 20px;
-    }
-  }
 </style>
+
+<div class="dish {column == 0 ? 'leftDishPad' : 'rightDishPad'}">
+  <h4>
+    <li>{dish.nombre}</li>
+  </h4>
+  <ul class="details">
+    <li>
+      <span>{formatDescription(dish) || ''}</span>
+      <span>${dish.precio}</span>
+    </li>
+  </ul>
+</div>
+<!-- dish end -->

--- a/src/components/menucategory/whitecategory.svelte
+++ b/src/components/menucategory/whitecategory.svelte
@@ -1,26 +1,17 @@
 <script>
-  import { onMount } from 'svelte';
-  import Dish from "../dish/whitedish.svelte"
-  import { getDishes } from '../../utils/api'
-  export let category
-  let fetch=true;
-  let dishes=[] 
+  import { onMount } from "svelte";
+  import Dish from "../dish/whitedish.svelte";
+  import { getDishes } from "../../utils/api";
+  export let category;
+  export let column;
+  let fetch = true;
+  let dishes = [];
 
   onMount(async () => {
     dishes = await getDishes(category);
-    fetch=false;
-	});
+    fetch = false;
+  });
 </script>
-{#if dishes.length > 0}
-<article class="menu-category">
-  <h2>{category.nombre}</h2>
-  {#each dishes as dish}
-    <Dish dish={dish} />
-  {/each}
-</article>
-{:else}
-<p>fetching dishes</p>
-{/if} 
 
 <style>
   .menu-category {
@@ -30,17 +21,31 @@
   page-break-inside: avoid;
   break-inside: avoid; */
   }
-
   .menu-category h2 {
     text-transform: uppercase;
     font-size: 1.5em;
     margin: 15px 0;
     padding: 5px 25px;
     border: 2px solid #000;
-    border-left:0;
-    border-right:0;
+    border-left: 0;
+    border-right: 0;
   }
-  .column article:nth-child(1) h2{
+
+  .pl {
+    padding-left: 10% !important;
+  }
+  .column article:nth-child(1) h2 {
     margin: 0;
   }
 </style>
+
+{#if dishes.length > 0}
+  <article class="menu-category">
+    <h2 class={column == 0 ? '' : 'pl'}>{category.nombre}</h2>
+    {#each dishes as dish}
+      <Dish {dish} {column} />
+    {/each}
+  </article>
+{:else}
+  <p>fetching dishes</p>
+{/if}

--- a/src/components/redtemplate.svelte
+++ b/src/components/redtemplate.svelte
@@ -147,13 +147,7 @@
 
     .menu.red-menu .menu-content {
       column-count: 3;
-      column-gap: 60px;
     }
   }
 
-  @media (min-width: 1400px) {
-    .menu-content {
-      grid-column-gap: 200px;
-    }
-  }
 </style>

--- a/src/components/whitetemplate.svelte
+++ b/src/components/whitetemplate.svelte
@@ -1,53 +1,30 @@
 <script>
-  import Category from "./menucategory/whitecategory.svelte"
-  import { getCategories, getImageUrl } from '../utils/api';
-  import { onMount } from 'svelte';
-  export let menu
-  let categories
-  let columns = [[],[]]
+  import Category from "./menucategory/whitecategory.svelte";
+  import { getCategories, getImageUrl } from "../utils/api";
+  import { onMount } from "svelte";
+  export let menu;
+  let categories;
+  let columns = [[], []];
 
   onMount(async () => {
     categories = await getCategories(menu);
-    columns = Object.keys(categories).reduce((cols, cat, i) => {
-      const c = i % 2
-      cols[c].push(categories[cat])
-      return cols
-    }, [[], []])
-	});
+    columns = Object.keys(categories).reduce(
+      (cols, cat, i) => {
+        const c = i % 2;
+        cols[c].push(categories[cat]);
+        return cols;
+      },
+      [[], []]
+    );
+  });
 </script>
-<svelte:head>
-  <title>{menu.nombre?menu.nombre:''}  | Restaurantalia</title>
-  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@300;400;600;700&display=swap" rel="stylesheet">
-</svelte:head>
-
-<section class="menu white-menu">
-  <div class="container">
-    {#if menu.menus_template.logo}
-    <div class="logo">
-      <img alt="restaurant name" src="{getImageUrl(menu.menus_template.logo)}" />
-    </div>
-    {/if}
-    <div class="separator">
-      <h1>MENÚ</h1>
-    </div>
-    <div class="menu-content">
-      {#each columns as column,i}
-        <div class="column">
-          {#each column as category,j}
-              <Category category={category} />
-          {/each}
-        </div>
-      {/each}
-    </div>
-  </div>
-</section>
 
 <style>
   :global(html, body, span, a, button, div, h1, h2) {
-    font-family: 'Oswald', sans-serif;
+    font-family: "Oswald", sans-serif;
   }
-  .container{
-    background-color: #F0EFED;
+  .container {
+    background-color: #f0efed;
   }
   .menu {
     color: #000;
@@ -70,21 +47,27 @@
   }
 
   .menu .logo img {
-    max-width: 160px;
+    max-width: 250px;
     position: relative;
     z-index: 1;
   }
 
   .menu .separator h1 {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     text-align: center;
     font-size: 1.5em;
     margin: 15px 10% 0px 10%;
   }
-  .menu .separator h1:before, .menu h1:after{
-    content:'●●●'
+  .menu .separator h1:before,
+  .menu h1:after {
+    content: "●●●";
+    font-size: 0.5em;
+    padding: 0 0.5em;
   }
 
-  .separator{
+  .separator {
     border-top: solid 2px #000;
     margin: 10px 2%;
   }
@@ -123,11 +106,13 @@
       display: none;
     }
     .menu .separator h1 {
-    text-align: center;
-    font-size: 2em;
-    margin: 15px 10% 0px 10%;
-  }
-
+      text-align: center;
+      font-size: 2em;
+      margin: 15px 10% 0px 10%;
+    }
+    .menu .logo img {
+      max-width: 300px;
+    }
     .menu.white-menu .menu-content {
       padding: 0px 0px 15px 0;
       display: flex;
@@ -139,17 +124,48 @@
       flex: 1 0 50%;
       box-sizing: border-box;
     }
-    .column:nth-child(1){
+    .column:nth-child(1) {
       border-right: 2px solid #000;
     }
-
   }
 
   @media (min-width: 1100px) {
-
+    .menu .logo img {
+      max-width: 380px;
+    }
     .menu.white-menu .menu-content {
       column-count: 3;
     }
   }
-
 </style>
+
+<svelte:head>
+  <title>{menu.nombre ? menu.nombre : ''} | Restaurantalia</title>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Oswald:wght@300;400;600;700&display=swap"
+    rel="stylesheet" />
+</svelte:head>
+
+<section class="menu white-menu">
+  <div class="container">
+    {#if menu.menus_template.logo}
+      <div class="logo">
+        <img
+          alt="restaurant name"
+          src={getImageUrl(menu.menus_template.logo)} />
+      </div>
+    {/if}
+    <div class="separator">
+      <h1>MENÚ</h1>
+    </div>
+    <div class="menu-content">
+      {#each columns as column, i}
+        <div class="column">
+          {#each column as category, j}
+            <Category {category} column={i} />
+          {/each}
+        </div>
+      {/each}
+    </div>
+  </div>
+</section>

--- a/src/components/whitetemplate.svelte
+++ b/src/components/whitetemplate.svelte
@@ -149,13 +149,7 @@
 
     .menu.white-menu .menu-content {
       column-count: 3;
-      column-gap: 60px;
     }
   }
 
-  @media (min-width: 1400px) {
-    .menu-content {
-      grid-column-gap: 200px;
-    }
-  }
 </style>

--- a/src/routes/demo.svelte
+++ b/src/routes/demo.svelte
@@ -141,10 +141,5 @@
     }
   }
 
-  @media (min-width: 1400px) {
-    .menu-content {
-      grid-column-gap: 200px;
-      /* column-gap: 200px; */
-    }
-  }
+  
 </style>

--- a/src/routes/demodark.svelte
+++ b/src/routes/demodark.svelte
@@ -93,7 +93,6 @@
     .menu.dark-menu .menu-content {
       padding: 30px;
       column-count: 2;
-      column-gap: 20px;
       /* display: grid;
     grid-template-columns: repeat(2, minmax(300px, 1fr));
     align-items: start;
@@ -105,16 +104,10 @@
 
     .menu.dark-menu .menu-content {
       column-count: 3;
-      column-gap: 60px;
       /* grid-template-columns: repeat(3, minmax(300px, 1fr));
     grid-column-gap: 60px; */
     }
   }
 
-  @media (min-width: 1400px) {
-    .menu-content {
-      grid-column-gap: 200px;
-      /* column-gap: 200px; */
-    }
-  }
+ 
 </style>

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,4 +1,7 @@
 function formatDescription({descripcion}){
+  if(!descripcion){
+    return descripcion;
+  }
   let lastChar = descripcion.slice(-1);
   return lastChar == '.'? descripcion.slice(0,-1):descripcion;
 }


### PR DESCRIPTION
#### What does this PR do?
* Fix the css for firefox visualization.
* Changed logo size on white template 
* Added padding to white menu
* Fix dotted line for prices (not handled correctly when description is just a line of text)
* Autoformatter
* Changed utility function to handle error
#### Where should the reviewer start from?
`src/components`
#### Any background context you want to provide?
Removed `column-gap` and `grid-column-gap` properties; those were showing bad on firefox in white and brown template, probabbly in dark template too (not enought data to test so far).

